### PR TITLE
MB-57952: Mixed mode support

### DIFF
--- a/base/mcreqeust_pool.go
+++ b/base/mcreqeust_pool.go
@@ -64,6 +64,7 @@ func (pool *MCRequestPool) cleanReq(req *WrappedMCRequest) *WrappedMCRequest {
 	req.SiblingReqs = req.SiblingReqs[:0]
 	req.SiblingReqsMtx.Unlock()
 	req.RetryCRCount = 0
+	req.NeedToRecompress = false
 	return req
 }
 

--- a/base/simple_utils.go
+++ b/base/simple_utils.go
@@ -2043,7 +2043,7 @@ func DecodeSubDocResp(key []byte, lookupResp *SubdocLookupResponse) (DocumentMet
 	specs := lookupResp.Specs
 	resp := lookupResp.Resp
 	body := resp.Body
-	if IsSuccessSubdocLookupResponse(resp) == false {
+	if IsSuccessGetResponse(resp) == false {
 		return DocumentMetadata{}, fmt.Errorf("Cannot decode subdoc lookup response because the lookup failed with status %v", resp.Status)
 	}
 	pos := 0

--- a/base/types.go
+++ b/base/types.go
@@ -902,6 +902,8 @@ type VBErrorEventAdditional struct {
 	ErrorType VBErrorType
 }
 
+type UncompressFunc func(req *WrappedMCRequest) error
+
 type ConflictResolutionMode int
 
 const (

--- a/base/types.go
+++ b/base/types.go
@@ -691,6 +691,7 @@ type WrappedMCRequest struct {
 	SlicesToBeReleasedMtx      sync.Mutex
 	ReqBytesCachedMtx          sync.RWMutex
 	ReqBytesCached             []byte
+	NeedToRecompress           bool
 
 	// If a single source mutation is translated to multiple target requests, the additional ones are listed here
 	SiblingReqs    []*WrappedMCRequest

--- a/base/types.go
+++ b/base/types.go
@@ -2568,3 +2568,12 @@ func (doc_meta *DocumentMetadata) CloneAndRedact() *DocumentMetadata {
 func (docMeta *DocumentMetadata) IsLocked() bool {
 	return docMeta != nil && docMeta.Cas == MaxCas
 }
+
+func IsDocLocked(resp *gomemcached.MCResponse) bool {
+	if resp.Opcode == GET_WITH_META && resp.Cas == MaxCas {
+		return true
+	} else if resp.Opcode == gomemcached.SUBDOC_MULTI_LOOKUP && resp.Status == gomemcached.LOCKED {
+		return true
+	}
+	return false
+}

--- a/base/xmem_client.go
+++ b/base/xmem_client.go
@@ -345,7 +345,9 @@ func IsIgnorableMCResponse(resp *gomemcached.MCResponse, caslock bool) bool {
 	return false
 }
 
-func IsSuccessSubdocLookupResponse(resp *gomemcached.MCResponse) bool {
+// getMeta will return SUCCESS
+// subdoc_multi_lookup may return the other status that are also success.
+func IsSuccessGetResponse(resp *gomemcached.MCResponse) bool {
 	if resp == nil {
 		return false
 	}

--- a/parts/capi_nozzle.go
+++ b/parts/capi_nozzle.go
@@ -607,12 +607,12 @@ func (capi *CapiNozzle) send_internal(batch *capiBatch) error {
 		// A map of documents that should not be replicated
 		var bigDoc_noRep_map map[string]NeedSendStatus
 		// Populate no replication map to optimize data bandwidth before actually sending
-		bigDoc_noRep_map, err = capi.batchGetMeta(batch.vbno, batch.getMeta_map)
+		bigDoc_noRep_map, err = capi.batchGetMeta(batch.vbno, batch.getMetaMap)
 		if err != nil {
 			capi.Logger().Errorf("%v batchGetMeta failed. err=%v\n", capi.Id(), err)
 		} else {
 			// Attach the map to the batch before actually sending
-			batch.noRep_map = bigDoc_noRep_map
+			batch.noRepMap = bigDoc_noRep_map
 		}
 
 		//batch send

--- a/parts/mocks/mock_ConflictResolver.go
+++ b/parts/mocks/mock_ConflictResolver.go
@@ -26,23 +26,23 @@ func (_m *ConflictResolver) EXPECT() *ConflictResolver_Expecter {
 	return &ConflictResolver_Expecter{mock: &_m.Mock}
 }
 
-// Execute provides a mock function with given fields: req, resp, specs, sourceId, targetId, xattrEnabled, logger
-func (_m *ConflictResolver) Execute(req *base.WrappedMCRequest, resp *gomemcached.MCResponse, specs []base.SubdocLookupPathSpec, sourceId hlv.DocumentSourceId, targetId hlv.DocumentSourceId, xattrEnabled bool, logger *log.CommonLogger) (base.ConflictResult, error) {
-	ret := _m.Called(req, resp, specs, sourceId, targetId, xattrEnabled, logger)
+// Execute provides a mock function with given fields: req, resp, specs, sourceId, targetId, xattrEnabled, uncompressFunc, logger
+func (_m *ConflictResolver) Execute(req *base.WrappedMCRequest, resp *gomemcached.MCResponse, specs []base.SubdocLookupPathSpec, sourceId hlv.DocumentSourceId, targetId hlv.DocumentSourceId, xattrEnabled bool, uncompressFunc base.UncompressFunc, logger *log.CommonLogger) (base.ConflictResult, error) {
+	ret := _m.Called(req, resp, specs, sourceId, targetId, xattrEnabled, uncompressFunc, logger)
 
 	var r0 base.ConflictResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*base.WrappedMCRequest, *gomemcached.MCResponse, []base.SubdocLookupPathSpec, hlv.DocumentSourceId, hlv.DocumentSourceId, bool, *log.CommonLogger) (base.ConflictResult, error)); ok {
-		return rf(req, resp, specs, sourceId, targetId, xattrEnabled, logger)
+	if rf, ok := ret.Get(0).(func(*base.WrappedMCRequest, *gomemcached.MCResponse, []base.SubdocLookupPathSpec, hlv.DocumentSourceId, hlv.DocumentSourceId, bool, base.UncompressFunc, *log.CommonLogger) (base.ConflictResult, error)); ok {
+		return rf(req, resp, specs, sourceId, targetId, xattrEnabled, uncompressFunc, logger)
 	}
-	if rf, ok := ret.Get(0).(func(*base.WrappedMCRequest, *gomemcached.MCResponse, []base.SubdocLookupPathSpec, hlv.DocumentSourceId, hlv.DocumentSourceId, bool, *log.CommonLogger) base.ConflictResult); ok {
-		r0 = rf(req, resp, specs, sourceId, targetId, xattrEnabled, logger)
+	if rf, ok := ret.Get(0).(func(*base.WrappedMCRequest, *gomemcached.MCResponse, []base.SubdocLookupPathSpec, hlv.DocumentSourceId, hlv.DocumentSourceId, bool, base.UncompressFunc, *log.CommonLogger) base.ConflictResult); ok {
+		r0 = rf(req, resp, specs, sourceId, targetId, xattrEnabled, uncompressFunc, logger)
 	} else {
 		r0 = ret.Get(0).(base.ConflictResult)
 	}
 
-	if rf, ok := ret.Get(1).(func(*base.WrappedMCRequest, *gomemcached.MCResponse, []base.SubdocLookupPathSpec, hlv.DocumentSourceId, hlv.DocumentSourceId, bool, *log.CommonLogger) error); ok {
-		r1 = rf(req, resp, specs, sourceId, targetId, xattrEnabled, logger)
+	if rf, ok := ret.Get(1).(func(*base.WrappedMCRequest, *gomemcached.MCResponse, []base.SubdocLookupPathSpec, hlv.DocumentSourceId, hlv.DocumentSourceId, bool, base.UncompressFunc, *log.CommonLogger) error); ok {
+		r1 = rf(req, resp, specs, sourceId, targetId, xattrEnabled, uncompressFunc, logger)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -62,14 +62,15 @@ type ConflictResolver_Execute_Call struct {
 //   - sourceId hlv.DocumentSourceId
 //   - targetId hlv.DocumentSourceId
 //   - xattrEnabled bool
+//   - uncompressFunc base.UncompressFunc
 //   - logger *log.CommonLogger
-func (_e *ConflictResolver_Expecter) Execute(req interface{}, resp interface{}, specs interface{}, sourceId interface{}, targetId interface{}, xattrEnabled interface{}, logger interface{}) *ConflictResolver_Execute_Call {
-	return &ConflictResolver_Execute_Call{Call: _e.mock.On("Execute", req, resp, specs, sourceId, targetId, xattrEnabled, logger)}
+func (_e *ConflictResolver_Expecter) Execute(req interface{}, resp interface{}, specs interface{}, sourceId interface{}, targetId interface{}, xattrEnabled interface{}, uncompressFunc interface{}, logger interface{}) *ConflictResolver_Execute_Call {
+	return &ConflictResolver_Execute_Call{Call: _e.mock.On("Execute", req, resp, specs, sourceId, targetId, xattrEnabled, uncompressFunc, logger)}
 }
 
-func (_c *ConflictResolver_Execute_Call) Run(run func(req *base.WrappedMCRequest, resp *gomemcached.MCResponse, specs []base.SubdocLookupPathSpec, sourceId hlv.DocumentSourceId, targetId hlv.DocumentSourceId, xattrEnabled bool, logger *log.CommonLogger)) *ConflictResolver_Execute_Call {
+func (_c *ConflictResolver_Execute_Call) Run(run func(req *base.WrappedMCRequest, resp *gomemcached.MCResponse, specs []base.SubdocLookupPathSpec, sourceId hlv.DocumentSourceId, targetId hlv.DocumentSourceId, xattrEnabled bool, uncompressFunc base.UncompressFunc, logger *log.CommonLogger)) *ConflictResolver_Execute_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*base.WrappedMCRequest), args[1].(*gomemcached.MCResponse), args[2].([]base.SubdocLookupPathSpec), args[3].(hlv.DocumentSourceId), args[4].(hlv.DocumentSourceId), args[5].(bool), args[6].(*log.CommonLogger))
+		run(args[0].(*base.WrappedMCRequest), args[1].(*gomemcached.MCResponse), args[2].([]base.SubdocLookupPathSpec), args[3].(hlv.DocumentSourceId), args[4].(hlv.DocumentSourceId), args[5].(bool), args[6].(base.UncompressFunc), args[7].(*log.CommonLogger))
 	})
 	return _c
 }
@@ -79,7 +80,7 @@ func (_c *ConflictResolver_Execute_Call) Return(_a0 base.ConflictResult, _a1 err
 	return _c
 }
 
-func (_c *ConflictResolver_Execute_Call) RunAndReturn(run func(*base.WrappedMCRequest, *gomemcached.MCResponse, []base.SubdocLookupPathSpec, hlv.DocumentSourceId, hlv.DocumentSourceId, bool, *log.CommonLogger) (base.ConflictResult, error)) *ConflictResolver_Execute_Call {
+func (_c *ConflictResolver_Execute_Call) RunAndReturn(run func(*base.WrappedMCRequest, *gomemcached.MCResponse, []base.SubdocLookupPathSpec, hlv.DocumentSourceId, hlv.DocumentSourceId, bool, base.UncompressFunc, *log.CommonLogger) (base.ConflictResult, error)) *ConflictResolver_Execute_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/parts/outgoing_nozzle_common.go
+++ b/parts/outgoing_nozzle_common.go
@@ -213,16 +213,16 @@ type dataBatch struct {
 	// They can be documents larger than optimistic replication threshold or
 	// documents that needs source side custom conflict resolution.
 	// Key of the map is the document unique key
-	getMeta_map base.McRequestMap
+	getMetaMap base.McRequestMap
 	// tracks docs that do not need to be replicated based on source side conflict resolution
 	// key of the map is the document key_revSeqno
 	// value of the map can be anything except Send. Anything not in the map will be sent through setWithMeta
-	noRep_map map[string]NeedSendStatus
-	// For CCR, noRep_map value may be Not_Send_Merge or Not_Send_Setback. For these, the target document lookup
+	noRepMap map[string]NeedSendStatus
+	// For CCR, noRepMap value may be Not_Send_Merge or Not_Send_Setback. For these, the target document lookup
 	// response is stored in here.
-	mergeLookup_map map[string]*base.SubdocLookupResponse
+	mergeLookupMap map[string]*base.SubdocLookupResponse
 	// If mobile is on, for document winning conflict resolution, we need to preserve target _sync XATTR. The lookup for these are stored in here
-	sendLookup_map map[string]*base.SubdocLookupResponse
+	sendLookupMap map[string]*base.SubdocLookupResponse
 
 	// XMEM config may change but only affect the next batch
 	// At the beginning of each batch we will check the config to decide the getMeta/getSubdoc and setMeta behavior
@@ -248,10 +248,10 @@ func newBatch(cap_count uint32, cap_size uint32, logger *log.CommonLogger) *data
 		curSize:           0,
 		capacity_count:    cap_count,
 		capacity_size:     cap_size,
-		getMeta_map:       make(base.McRequestMap),
-		noRep_map:         nil,
-		mergeLookup_map:   nil,
-		sendLookup_map:    nil,
+		getMetaMap:        make(base.McRequestMap),
+		noRepMap:          nil,
+		mergeLookupMap:    nil,
+		sendLookupMap:     nil,
 		batch_nonempty_ch: make(chan bool),
 		nonempty_set:      false,
 		setMetaXattrOptions: SetMetaXattrOptions{
@@ -279,7 +279,7 @@ func (b *dataBatch) accumuBatch(req *base.WrappedMCRequest, classifyFunc func(re
 		}
 		if !classifyFunc(req.Req) {
 			// If it fails the classifyFunc, then we're going to do bigDoc processing on it
-			b.getMeta_map[req.UniqueKey] = req
+			b.getMetaMap[req.UniqueKey] = req
 		}
 		curSize := b.incrementSize(uint32(size))
 		if curCount < b.capacity_count && curSize < b.capacity_size*1000 {
@@ -319,7 +319,7 @@ func needSend(req *base.WrappedMCRequest, batch *dataBatch, logger *log.CommonLo
 		return Send, errors.New("needSend saw a nil req")
 	}
 
-	failedCR, ok := batch.noRep_map[req.UniqueKey]
+	failedCR, ok := batch.noRepMap[req.UniqueKey]
 	if !ok {
 		return Send, nil
 	} else {

--- a/parts/xmem_nozzle.go
+++ b/parts/xmem_nozzle.go
@@ -84,7 +84,7 @@ var ErrorXmemIsStuck = errors.New("Xmem is stuck")
 
 var ErrorBufferInvalidState = errors.New("xmem buffer is in invalid state")
 
-type ConflictResolver func(req *base.WrappedMCRequest, resp *mc.MCResponse, specs []base.SubdocLookupPathSpec, sourceId, targetId hlv.DocumentSourceId, xattrEnabled bool, logger *log.CommonLogger) (base.ConflictResult, error)
+type ConflictResolver func(req *base.WrappedMCRequest, resp *mc.MCResponse, specs []base.SubdocLookupPathSpec, sourceId, targetId hlv.DocumentSourceId, xattrEnabled bool, uncompressFunc base.UncompressFunc, logger *log.CommonLogger) (base.ConflictResult, error)
 
 var GetMetaClientName = "client_getMeta"
 var SetMetaClientName = "client_setMeta"
@@ -1309,7 +1309,7 @@ func (xmem *XmemNozzle) batchSetMetaWithRetry(batch *dataBatch, numOfRetry int) 
 						batch.mergeLookupMap[item.UniqueKey])
 					panic(fmt.Sprintf("No response for key %v", item.UniqueKey))
 				}
-				err = xmem.conflictMgr.ResolveConflict(item, lookupResp, xmem.sourceBucketId, xmem.targetBucketId, xmem.recycleDataObj)
+				err = xmem.conflictMgr.ResolveConflict(item, lookupResp, xmem.sourceBucketId, xmem.targetBucketId, xmem.uncompressBody, xmem.recycleDataObj)
 				if err != nil {
 					return err
 				}
@@ -1320,7 +1320,7 @@ func (xmem *XmemNozzle) batchSetMetaWithRetry(batch *dataBatch, numOfRetry int) 
 					panic(fmt.Sprintf("No response for key %v", item.UniqueKey))
 				}
 				// This is the case where target has smaller CAS but it dominates source MV.
-				err = xmem.conflictMgr.SetBackToSource(item, lookupResp, xmem.sourceBucketId, xmem.targetBucketId, xmem.recycleDataObj)
+				err = xmem.conflictMgr.SetBackToSource(item, lookupResp, xmem.sourceBucketId, xmem.targetBucketId, xmem.uncompressBody, xmem.recycleDataObj)
 				if err != nil {
 					return err
 				}
@@ -1779,12 +1779,8 @@ func (xmem *XmemNozzle) batchGet(get_map base.McRequestMap, getSpecWithHlv, getS
 				noRep_map[uniqueKey] = RetryTargetLocked
 				delete(get_map, uniqueKey)
 			} else if ok && base.IsSuccessGetResponse(resp.Resp) {
-				if err = xmem.uncompressBody(wrappedReq); err != nil {
-					xmem.Logger().Errorf("%v failed to uncompress %v%q%v: '%v'", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd, err)
-					return nil, nil, nil, nil, err
-				}
 				var res base.ConflictResult
-				res, err = xmem.conflict_resolver(wrappedReq, resp.Resp, resp.Specs, xmem.sourceBucketId, xmem.targetBucketId, xmem.xattrEnabled, xmem.Logger())
+				res, err = xmem.conflict_resolver(wrappedReq, resp.Resp, resp.Specs, xmem.sourceBucketId, xmem.targetBucketId, xmem.xattrEnabled, xmem.uncompressBody, xmem.Logger())
 				if err != nil {
 					// Log the error. We will retry
 					xmem.Logger().Errorf("%v conflict_resolver: '%v'", xmem.Id(), err)
@@ -1984,7 +1980,7 @@ func (xmem *XmemNozzle) updateSystemXattrForTarget(wrappedReq *base.WrappedMCReq
 	var meta *crMeta.CRMetadata
 	if setOpt.sendHlv {
 		doc := crMeta.NewSourceDocument(wrappedReq, xmem.sourceBucketId)
-		meta, err = doc.GetMetadata()
+		meta, err = doc.GetMetadata(xmem.uncompressBody)
 		if err != nil {
 			return err
 		}
@@ -2054,12 +2050,10 @@ func (xmem *XmemNozzle) isChangesFromTarget(req *base.WrappedMCRequest) (bool, e
 	if xmem.source_cr_mode != base.CRMode_Custom {
 		return false, nil
 	}
-	if err := xmem.uncompressBody(req); err != nil {
-		return false, err
-	}
+
 	if req.RetryCRCount == 0 {
 		doc := crMeta.NewSourceDocument(req, xmem.sourceBucketId)
-		meta, err := doc.GetMetadata()
+		meta, err := doc.GetMetadata(xmem.uncompressBody)
 		if err != nil {
 			return false, err
 		}

--- a/parts/xmem_nozzle.go
+++ b/parts/xmem_nozzle.go
@@ -1399,7 +1399,7 @@ func (xmem *XmemNozzle) preprocessMCRequest(req *base.WrappedMCRequest, lookup *
 	xmem.setCasLocking(req, lookup, setMetaOptions)
 
 	// Compress it if needed
-	if (setMetaOptions.sendHlv || setMetaOptions.preserveSync) && mc_req.DataType&mcc.SnappyDataType == 0 {
+	if req.NeedToRecompress && mc_req.DataType&mcc.SnappyDataType == 0 {
 		maxEncodedLen := snappy.MaxEncodedLen(len(mc_req.Body))
 		if maxEncodedLen > 0 && maxEncodedLen < len(mc_req.Body) {
 			body, err := xmem.dataPool.GetByteSlice(uint64(maxEncodedLen))
@@ -1417,6 +1417,7 @@ func (xmem *XmemNozzle) preprocessMCRequest(req *base.WrappedMCRequest, lookup *
 			body = snappy.Encode(body, mc_req.Body)
 			mc_req.Body = body
 			mc_req.DataType = mc_req.DataType | mcc.SnappyDataType
+			req.NeedToRecompress = false
 		}
 	}
 	req.UpdateReqBytes()
@@ -1832,6 +1833,11 @@ func (xmem *XmemNozzle) opcodeAndSpecsForGetOp(incomingReq *mc.MCRequest, getSpe
 		getSpecs = getSpecWithHlv
 	} else if xmem.getCrossClusterVers() == true && incomingReq.Cas >= xmem.config.vbMaxCas[incomingReq.VBucket] {
 		// These are the mutations we need to maintain HLV for mobile and get target importCas/cvCas for CR
+		// Note that there is no mixed mode support for import mutations. If enableCrossClusterVersioning is false,
+		// and current source mutation already has HLV, we still don't get target importCas/HLV. The reason is to
+		// figure out that current source mutation already has HLV will require us to parse the body. It has a
+		// performance impact. Mobile does not expect to support import in mixed mode. Doing import during mixed
+		// mode may cause data loss. See design spec for more details.
 		getSpecs = getSpecWithHlv
 	} else {
 		getSpecs = getSpecWithoutHlv
@@ -1912,6 +1918,7 @@ func (xmem *XmemNozzle) uncompressBody(req *base.WrappedMCRequest) error {
 		}
 		req.Req.Body = body
 		req.Req.DataType = req.Req.DataType &^ mcc.SnappyDataType
+		req.NeedToRecompress = true
 		req.UpdateReqBytes()
 	}
 	return nil

--- a/parts/xmem_nozzle.go
+++ b/parts/xmem_nozzle.go
@@ -564,7 +564,7 @@ func (config *xmemConfig) initializeConfig(settings metadata.ReplicationSettings
 					casStr := casObj.(string)
 					cas, err := strconv.ParseUint(casStr, 10, 64)
 					if err != nil {
-						return fmt.Errorf("bad value %v in vbucketsMaxCas %v", casStr, vbMaxCas)
+						return fmt.Errorf("bad value %v in vbucketsMaxCas %v. err=%v", casStr, vbMaxCas, err)
 					}
 					config.vbMaxCas[uint16(i)] = cas
 				}
@@ -1104,7 +1104,7 @@ func (xmem *XmemNozzle) processData_sendbatch(finch chan bool, waitGrp *sync.Wai
 			}
 
 			// batchGet may use getMeta or subdoc_multi_lookup to get the results.
-			noRepMap, conflictMap, sendLookup_map, _, err := xmem.batchGet(batch.getMeta_map, batch.getMetaSpecWithHlv, batch.getMetaSpecWithoutHlv)
+			noRepMap, conflictMap, sendLookup_map, _, err := xmem.batchGet(batch.getMetaMap, batch.getMetaSpecWithHlv, batch.getMetaSpecWithoutHlv)
 			if err != nil {
 				if err == PartStoppedError {
 					goto done
@@ -1134,10 +1134,10 @@ func (xmem *XmemNozzle) processData_sendbatch(finch chan bool, waitGrp *sync.Wai
 					// Anything to be sent should not be in noRepMap
 					delete(noRepMap, k)
 				}
-				batch.mergeLookup_map = mergeLookupMap
+				batch.mergeLookupMap = mergeLookupMap
 			}
-			batch.noRep_map = noRepMap
-			batch.sendLookup_map = sendLookup_map
+			batch.noRepMap = noRepMap
+			batch.sendLookupMap = sendLookup_map
 
 			err = xmem.processBatch(batch)
 			if err != nil {
@@ -1257,7 +1257,7 @@ func (xmem *XmemNozzle) batchSetMetaWithRetry(batch *dataBatch, numOfRetry int) 
 			}
 			switch needSendStatus {
 			case Send:
-				lookupResp := batch.sendLookup_map[item.UniqueKey]
+				lookupResp := batch.sendLookupMap[item.UniqueKey]
 				err = xmem.preprocessMCRequest(item, lookupResp, batch.setMetaXattrOptions)
 				if err != nil {
 					return err
@@ -1302,11 +1302,11 @@ func (xmem *XmemNozzle) batchSetMetaWithRetry(batch *dataBatch, numOfRetry int) 
 			case NotSendMerge:
 				// Call conflictMgr to resolve conflict
 				atomic.AddUint64(&xmem.counter_to_resolve, 1)
-				lookupResp, ok := batch.mergeLookup_map[item.UniqueKey]
+				lookupResp, ok := batch.mergeLookupMap[item.UniqueKey]
 				if !ok || lookupResp == nil {
 					xmem.Logger().Errorf("key=%q, batch.noRep=%v, sendLookup=%v, mergeLookup=%v\n",
-						[]byte(item.UniqueKey), batch.noRep_map[item.UniqueKey], batch.sendLookup_map[item.UniqueKey],
-						batch.mergeLookup_map[item.UniqueKey])
+						[]byte(item.UniqueKey), batch.noRepMap[item.UniqueKey], batch.sendLookupMap[item.UniqueKey],
+						batch.mergeLookupMap[item.UniqueKey])
 					panic(fmt.Sprintf("No response for key %v", item.UniqueKey))
 				}
 				err = xmem.conflictMgr.ResolveConflict(item, lookupResp, xmem.sourceBucketId, xmem.targetBucketId, xmem.recycleDataObj)
@@ -1315,7 +1315,7 @@ func (xmem *XmemNozzle) batchSetMetaWithRetry(batch *dataBatch, numOfRetry int) 
 				}
 			case NotSendSetback:
 				atomic.AddUint64(&xmem.counter_to_setback, 1)
-				lookupResp := batch.mergeLookup_map[item.UniqueKey]
+				lookupResp := batch.mergeLookupMap[item.UniqueKey]
 				if lookupResp == nil {
 					panic(fmt.Sprintf("No response for key %v", item.UniqueKey))
 				}
@@ -1629,10 +1629,10 @@ func (xmem *XmemNozzle) composeRequestForGetMeta(key []byte, vb uint16, opaque u
 	return req
 }
 
-// For each document in the get_map, this routine will compose subdoc_get or getMeta, and send the requests
-func (xmem *XmemNozzle) sendBatchGetRequest(get_map base.McRequestMap, retry int, getSpecWithHlv, getSpecWithoutHlv []base.SubdocLookupPathSpec) (respMap map[string]*base.SubdocLookupResponse, err error) {
+// For each document in the getMap, this routine will compose subdoc_get or getMeta, and send the requests
+func (xmem *XmemNozzle) sendBatchGetRequest(getMap base.McRequestMap, retry int, getSpecWithHlv, getSpecWithoutHlv []base.SubdocLookupPathSpec) (respMap map[string]*base.SubdocLookupResponse, err error) {
 	// if input size is 0, then we are done
-	if len(get_map) == 0 {
+	if len(getMap) == 0 {
 		return nil, nil
 	}
 
@@ -1654,15 +1654,15 @@ func (xmem *XmemNozzle) sendBatchGetRequest(get_map base.McRequestMap, retry int
 
 	// Establish an opaque based on the current time - and since getting doc doesn't utilize buffer buckets, feed it 0
 	opaque := base.GetOpaque(0, uint16(time.Now().UnixNano()))
-	sent_key_map := make(map[string]bool, len(get_map))
+	sent_key_map := make(map[string]bool, len(getMap))
 	getSpecMap := make(map[string][]base.SubdocLookupPathSpec)
 
 	//de-dupe and prepare the packages
-	for _, originalReq := range get_map {
+	for _, originalReq := range getMap {
 		docKey := string(originalReq.Req.Key)
 		if docKey == "" {
-			xmem.Logger().Errorf("%v received empty docKey. unique-key= %v%q%v, req=%v%v%v, getMeta_map=%v%v%v", xmem.Id(),
-				base.UdTagBegin, originalReq.Req.Key, base.UdTagEnd, base.UdTagBegin, originalReq.Req, base.UdTagEnd, base.UdTagBegin, get_map, base.UdTagEnd)
+			xmem.Logger().Errorf("%v received empty docKey. unique-key= %v%q%v, req=%v%v%v, getMetaMap=%v%v%v", xmem.Id(),
+				base.UdTagBegin, originalReq.Req.Key, base.UdTagEnd, base.UdTagBegin, originalReq.Req, base.UdTagEnd, base.UdTagBegin, getMap, base.UdTagEnd)
 			return respMap, errors.New(xmem.Id() + " received empty docKey.")
 		}
 
@@ -1736,17 +1736,17 @@ func (xmem *XmemNozzle) sendBatchGetRequest(get_map base.McRequestMap, retry int
 // - getSpecWithHlv: the spec for subdoc_get paths, if nil, getMeta will be used.
 // - getSpecWithoutHlv: the spec if not CCR and enableCrossClusterVersion is off. If nil, getMeta will be used
 // Output:
-// - noRep_map: the documents we don't need to send to target
-// - sendLookup_map: the response for documents we need to send to target. These are not in noRep_map.
-// - conflict_map: These documents have conflict. These are also in noRep_map with corresponding NeedSendStatus
-// - mergeLookup_map: The response for the documents in conflict_map
+// - noRepMap: the documents we don't need to send to target
+// - sendLookupMap: the response for documents we need to send to target. These are not in noRepMap.
+// - conflictMap: These documents have conflict. These are also in noRepMap with corresponding NeedSendStatus
+// - mergeLookupMap: The response for the documents in conflict_map
 func (xmem *XmemNozzle) batchGet(get_map base.McRequestMap, getSpecWithHlv, getSpecWithoutHlv []base.SubdocLookupPathSpec) (noRep_map map[string]NeedSendStatus,
-	conflict_map base.McRequestMap, sendLookup_map, mergeLookup_map map[string]*base.SubdocLookupResponse, err error) {
+	conflictMap base.McRequestMap, sendLookupMap, mergeLookupMap map[string]*base.SubdocLookupResponse, err error) {
 
 	noRep_map = make(map[string]NeedSendStatus)
-	conflict_map = make(base.McRequestMap)
-	sendLookup_map = make(map[string]*base.SubdocLookupResponse)
-	mergeLookup_map = make(map[string]*base.SubdocLookupResponse)
+	conflictMap = make(base.McRequestMap)
+	sendLookupMap = make(map[string]*base.SubdocLookupResponse)
+	mergeLookupMap = make(map[string]*base.SubdocLookupResponse)
 	var respMap map[string]*base.SubdocLookupResponse
 	var hasTmpErr bool
 	for i := 0; i < xmem.config.maxRetry || hasTmpErr; i++ {
@@ -1769,7 +1769,7 @@ func (xmem *XmemNozzle) batchGet(get_map base.McRequestMap, getSpecWithHlv, getS
 			key := string(wrappedReq.Req.Key)
 			resp, ok := respMap[key]
 			if ok && (resp.Resp.Status == mc.KEY_ENOENT) {
-				sendLookup_map[uniqueKey] = resp
+				sendLookupMap[uniqueKey] = resp
 				delete(get_map, uniqueKey)
 			} else if ok && base.IsDocLocked(resp.Resp) {
 				if xmem.Logger().GetLogLevel() >= log.LogLevelDebug {
@@ -1791,24 +1791,24 @@ func (xmem *XmemNozzle) batchGet(get_map base.McRequestMap, getSpecWithHlv, getS
 				}
 				switch res {
 				case base.SendToTarget:
-					sendLookup_map[uniqueKey] = resp
+					sendLookupMap[uniqueKey] = resp
 				case base.Skip:
 					noRep_map[uniqueKey] = NotSendFailedCR
 				case base.Merge:
 					noRep_map[uniqueKey] = NotSendMerge
-					conflict_map[uniqueKey] = wrappedReq
-					mergeLookup_map[uniqueKey] = resp
+					conflictMap[uniqueKey] = wrappedReq
+					mergeLookupMap[uniqueKey] = resp
 				case base.SetBackToSource:
 					noRep_map[uniqueKey] = NotSendSetback
-					conflict_map[uniqueKey] = wrappedReq
-					mergeLookup_map[uniqueKey] = resp
+					conflictMap[uniqueKey] = wrappedReq
+					mergeLookupMap[uniqueKey] = resp
 				default:
 					panic(fmt.Sprintf("Unexpcted conflict result %v", res))
 				}
 				delete(get_map, uniqueKey)
 			} else if opcode, _ := xmem.opcodeAndSpecsForGetOp(wrappedReq.Req, getSpecWithHlv, getSpecWithoutHlv); opcode == base.GET_WITH_META {
 				// For getMeta, we can just send optimistically
-				sendLookup_map[uniqueKey] = resp
+				sendLookupMap[uniqueKey] = resp
 				delete(get_map, uniqueKey)
 			} else if resp != nil {
 				if base.IsTemporaryMCError(resp.Resp.Status) {
@@ -1839,15 +1839,19 @@ func (xmem *XmemNozzle) opcodeAndSpecsForGetOp(incomingReq *mc.MCRequest, getSpe
 	if getSpecs == nil {
 		return base.GET_WITH_META, nil
 	}
-	return base.SUBDOC_MULTI_MUTATION, getSpecs
+	return mc.SUBDOC_MULTI_LOOKUP, getSpecs
 }
 
 func (xmem *XmemNozzle) composeRequestForGet(incomingReq *mc.MCRequest, getSpecWithHlv, getSpecWithoutHlv []base.SubdocLookupPathSpec, opaque uint32) (*mc.MCRequest, []base.SubdocLookupPathSpec) {
 	opcode, specs := xmem.opcodeAndSpecsForGetOp(incomingReq, getSpecWithHlv, getSpecWithoutHlv)
-	if opcode == base.GET_WITH_META {
+	switch opcode {
+	case base.GET_WITH_META:
 		return xmem.composeRequestForGetMeta(incomingReq.Key, incomingReq.VBucket, opaque), nil
+	case mc.SUBDOC_MULTI_LOOKUP:
+		return xmem.composeRequestForSubdocGet(specs, incomingReq.Key, incomingReq.VBucket, opaque), specs
+	default:
+		panic(fmt.Sprintf("Unknown opcode %v. Need to implement", opcode))
 	}
-	return xmem.composeRequestForSubdocGet(specs, incomingReq.Key, incomingReq.VBucket, opaque), specs
 }
 
 // Request to get _xdcr XATTR. If document body is included, it must be the last path
@@ -3093,7 +3097,7 @@ func (xmem *XmemNozzle) handleGeneralError(err error) {
 
 func (xmem *XmemNozzle) optimisticRep(req *mc.MCRequest) bool {
 	opcode, _ := xmem.opcodeAndSpecsForGetOp(req, xmem.batch.getMetaSpecWithHlv, xmem.batch.getMetaSpecWithoutHlv)
-	if opcode == base.SUBDOC_MULTI_MUTATION {
+	if opcode == mc.SUBDOC_MULTI_LOOKUP {
 		// If we need to get anything from target, optimisticRep can't be used.
 		return false
 	}

--- a/parts/xmem_nozzle.go
+++ b/parts/xmem_nozzle.go
@@ -557,17 +557,16 @@ func (config *xmemConfig) initializeConfig(settings metadata.ReplicationSettings
 			config.crossClusterVers = val.(bool)
 		}
 		if config.crossClusterVers {
-			config.vbMaxCas = make([]uint64, 1024)
+			config.vbMaxCas = make(map[uint16]uint64)
 			if val, ok := settings[base.VbucketsMaxCasKey]; ok {
 				vbMaxCas := val.([]interface{})
-				config.vbMaxCas = make([]uint64, len(vbMaxCas))
 				for i, casObj := range vbMaxCas {
 					casStr := casObj.(string)
 					cas, err := strconv.ParseUint(casStr, 10, 64)
 					if err != nil {
 						return fmt.Errorf("bad value %v in vbucketsMaxCas %v", casStr, vbMaxCas)
 					}
-					config.vbMaxCas[i] = cas
+					config.vbMaxCas[uint16(i)] = cas
 				}
 			}
 		}
@@ -1104,54 +1103,42 @@ func (xmem *XmemNozzle) processData_sendbatch(finch chan bool, waitGrp *sync.Wai
 				goto done
 			}
 
-			if len(batch.getMetaSpec) == 0 {
-				// There is no getMetaSpec. This is the default code path with no CCR or mobile.
-				// We get meta to find what needs not be sent. If getMeta fails, we just send and let target
-				// perform CR.
-				noRepMap, err := xmem.batchGetMeta(batch.getMeta_map)
-				if err != nil {
-					xmem.Logger().Errorf("%v batchGetMeta failed. err=%v\n", xmem.Id(), err)
-				} else {
-					batch.noRep_map = noRepMap
+			// batchGet may use getMeta or subdoc_multi_lookup to get the results.
+			noRepMap, conflictMap, sendLookup_map, _, err := xmem.batchGet(batch.getMeta_map, batch.getMetaSpecWithHlv, batch.getMetaSpecWithoutHlv)
+			if err != nil {
+				if err == PartStoppedError {
+					goto done
 				}
-			} else {
-				// There is a getMetaSpec to get metadata and XATTR. This can be CCR or non-CCR with mobile.
-				// In case of CCR, we have a conflict_map containing all keys with conflict.
-				noRepMap, conflictMap, sendLookup_map, _, err := xmem.batchSubDocGet(batch.getMeta_map, batch.getMetaSpec)
+				xmem.handleGeneralError(err)
+			}
+			if len(conflictMap) > 0 {
+				if xmem.source_cr_mode != base.CRMode_Custom {
+					panic(fmt.Sprintf("cr_mode=%v, conflict_map: %v", xmem.source_cr_mode, conflictMap))
+				}
+				// For all the keys with conflict, we will fetch the document metadata and body.
+				// With the new metadata, we do conflict detection again in case anything changed.
+				noRepMap2, _, sendLookupMap2, mergeLookupMap, err := xmem.batchGet(conflictMap, batch.getBodySpec, nil)
 				if err != nil {
 					if err == PartStoppedError {
 						goto done
 					}
 					xmem.handleGeneralError(err)
 				}
-				if len(conflictMap) > 0 {
-					if xmem.source_cr_mode != base.CRMode_Custom {
-						panic(fmt.Sprintf("cr_mode=%v, conflict_map: %v", xmem.source_cr_mode, conflictMap))
-					}
-					// For all the keys with conflict, we will fetch the document metadata and body.
-					// With the new metadata, we do conflict detection again in case anything changed.
-					noRepMap2, _, sendLookupMap2, mergeLookupMap, err := xmem.batchSubDocGet(conflictMap, batch.getBodySpec)
-					if err != nil {
-						if err == PartStoppedError {
-							goto done
-						}
-						xmem.handleGeneralError(err)
-					}
-					// Update the maps with the second round lookup and conflict detection results
-					// Can't loop through conflictMap because it is all deleted after batchSubDocGet returns.
-					for k, v := range noRepMap2 {
-						noRepMap[k] = v
-					}
-					for k, v := range sendLookupMap2 {
-						sendLookup_map[k] = v
-						// Anything to be sent should not be in noRepMap
-						delete(noRepMap, k)
-					}
-					batch.mergeLookup_map = mergeLookupMap
+				// Update the maps with the second round lookup and conflict detection results
+				// Can't loop through conflictMap because it is all deleted after batchGet returns.
+				for k, v := range noRepMap2 {
+					noRepMap[k] = v
 				}
-				batch.noRep_map = noRepMap
-				batch.sendLookup_map = sendLookup_map
+				for k, v := range sendLookupMap2 {
+					sendLookup_map[k] = v
+					// Anything to be sent should not be in noRepMap
+					delete(noRepMap, k)
+				}
+				batch.mergeLookup_map = mergeLookupMap
 			}
+			batch.noRep_map = noRepMap
+			batch.sendLookup_map = sendLookup_map
+
 			err = xmem.processBatch(batch)
 			if err != nil {
 				if err == PartStoppedError {
@@ -1276,6 +1263,11 @@ func (xmem *XmemNozzle) batchSetMetaWithRetry(batch *dataBatch, numOfRetry int) 
 					return err
 				}
 
+				if lookupResp != nil && lookupResp.Resp.Opcode == base.SUBDOC_MULTI_MUTATION {
+					xmem.batch.setMetaXattrOptions.noTargetCR = true
+				} else {
+					xmem.batch.setMetaXattrOptions.noTargetCR = false
+				}
 				//blocking
 				index, reserv_num, item_bytes, err := xmem.buf.enSlot(item, xmem.batch.setMetaXattrOptions)
 				if err != nil {
@@ -1502,20 +1494,14 @@ func (xmem *XmemNozzle) sendSetMeta_internal(batch *dataBatch) error {
 // Launched as a part of the batchGetMeta and batchSubdocGet,
 // which will fire off the requests and this is the handler to decrypt the info coming back
 func (xmem *XmemNozzle) batchGetHandler(count int, finch chan bool, return_ch chan bool,
-	opaque_keySeqno_map opaqueKeySeqnoMap, respMap base.MCResponseMap, logger *log.CommonLogger, isGetMeta bool) {
-	var batchGetStr string
-	if isGetMeta {
-		batchGetStr = "batchGetMeta"
-	} else {
-		batchGetStr = "batchSubdocGet"
-	}
+	opaque_keySeqno_map opaqueKeySeqnoMap, respMap map[string]*base.SubdocLookupResponse, getSpecMap map[string][]base.SubdocLookupPathSpec, logger *log.CommonLogger) {
 	defer func() {
 		//handle the panic gracefully.
 		if r := recover(); r != nil {
 			if xmem.validateRunningState() == nil {
 				errMsg := fmt.Sprintf("%v", r)
 				//add to the error list
-				xmem.Logger().Errorf("%v %v receiver recovered from err = %v", xmem.Id(), batchGetStr, errMsg)
+				xmem.Logger().Errorf("%v batchGet receiver recovered from err = %v", xmem.Id(), errMsg)
 
 				//repair the connection
 				xmem.repairConn(xmem.client_for_getMeta, errMsg, xmem.client_for_getMeta.RepairCount())
@@ -1554,15 +1540,15 @@ func (xmem *XmemNozzle) batchGetHandler(count int, finch chan bool, return_ch ch
 				}
 
 				if !isNetTimeoutError(err) && err != PartStoppedError {
-					logger.Errorf("%v %v received fatal error and had to abort. Expected %v responses, got %v responses. err=%v", xmem.Id(), batchGetStr, count, len(respMap), err)
+					logger.Errorf("%v batchGet received fatal error and had to abort. Expected %v responses, got %v responses. err=%v", xmem.Id(), count, len(respMap), err)
 					logger.Infof("%v Expected=%v, Received=%v\n", xmem.Id(), opaque_keySeqno_map.CloneAndRedact(), base.UdTagBegin, respMap, base.UdTagEnd)
 				} else {
-					logger.Errorf("%v %v timed out. Expected %v responses, got %v responses", xmem.Id(), batchGetStr, count, len(respMap))
+					logger.Errorf("%v batchGet timed out. Expected %v responses, got %v responses", xmem.Id(), count, len(respMap))
 					logger.Infof("%v Expected=%v, Received=%v\n", xmem.Id(), opaque_keySeqno_map.CloneAndRedact(), base.UdTagBegin, respMap, base.UdTagEnd)
 				}
 				return
-
 			} else {
+				isGetMeta := response.Opcode == base.GET_WITH_META
 				keySeqno, ok := opaque_keySeqno_map[response.Opaque]
 				if ok {
 					//success
@@ -1572,7 +1558,8 @@ func (xmem *XmemNozzle) batchGetHandler(count int, finch chan bool, return_ch ch
 					start_time, ok3 := keySeqno[3].(time.Time)
 					manifestId, ok4 := keySeqno[4].(uint64)
 					if ok1 && ok2 && ok3 && ok4 {
-						respMap[key] = response
+						specs := getSpecMap[key]
+						respMap[key] = &base.SubdocLookupResponse{specs, response}
 
 						// GetMeta successful means that the target manifest ID is valid for the collection ID of this key
 						additionalInfo := GetReceivedEventAdditional{Key: key,
@@ -1627,120 +1614,9 @@ func (xmem *XmemNozzle) batchGetHandler(count int, finch chan bool, return_ch ch
 	}
 }
 
-/**
- * batch call to memcached GetMeta command for document size larger than the optimistic threshold
- * Returns a map of all the keys that are fed in bigDoc_map, with a boolean value
- * The boolean value == true meaning that the document referred by key should *not* be replicated
- */
-func (xmem *XmemNozzle) batchGetMeta(bigDoc_map base.McRequestMap) (map[string]NeedSendStatus, error) {
-	bigDoc_noRep_map := make(NoRepMap)
-
-	//if the bigDoc_map size is 0, return
-	if len(bigDoc_map) == 0 {
-		return bigDoc_noRep_map, nil
-	}
-	respMap, _ := xmem.sendBatchGetRequest(bigDoc_map, 0, nil)
-	// Parse the result once the handler has finished populating the respMap
-	for _, wrappedReq := range bigDoc_map {
-		key := string(wrappedReq.Req.Key)
-		resp, ok := respMap[key]
-		if ok && resp.Status == mc.SUCCESS {
-			doc_meta_target, _ := base.DecodeGetMetaResp(wrappedReq.Req.Key, resp, xmem.xattrEnabled)
-			if doc_meta_target.IsLocked() {
-				if xmem.Logger().GetLogLevel() >= log.LogLevelDebug {
-					docMetaTgtRedacted := doc_meta_target.CloneAndRedact()
-					xmem.Logger().Debugf("%v doc %v%s%v is locked on the target, target meta=%v. will need to retry\n", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd, docMetaTgtRedacted)
-				}
-				bigDoc_noRep_map[wrappedReq.UniqueKey] = RetryTargetLocked
-			} else {
-				res, err := xmem.conflict_resolver(wrappedReq, resp, nil, xmem.sourceBucketId, xmem.targetBucketId, xmem.xattrEnabled, xmem.Logger())
-				if err != nil {
-					xmem.Logger().Warnf("%v batchGetMeta: Error decoding getMeta response for doc %v%s%v. err=%v. Skip conflict resolution and send the doc", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd, err)
-					continue
-				}
-				switch res {
-				case base.Skip:
-					if xmem.Logger().GetLogLevel() >= log.LogLevelDebug {
-						sourceDoc := crMeta.NewSourceDocument(wrappedReq, xmem.sourceBucketId)
-						sourceMeta, err := sourceDoc.GetMetadata()
-						if err != nil {
-							xmem.Logger().Warnf("%v batchGetMeta: Error decoding source document metadata for doc %v%q%v. err=%v. Skip conflict resolution and send the doc", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd, err)
-							continue
-						}
-						targetDoc, err := crMeta.NewTargetDocument([]byte(key), resp, nil, xmem.targetBucketId, xmem.xattrEnabled, false)
-						if err != nil {
-							xmem.Logger().Warnf("%v batchGetMeta: doc %v%q%v failed source side conflict resolution, but had error decoding target document metadata for logging. err=%v.",
-								xmem.Id(), base.UdTagBegin, key, base.UdTagEnd, err)
-							continue
-						}
-						targetMeta, err := targetDoc.GetMetadata()
-						if err != nil {
-							xmem.Logger().Warnf("%v batchGetMeta: Error decoding target document metadata for doc %v%q%v. err=%v. Skip conflict resolution and send the doc", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd, err)
-							continue
-						}
-						docMetaSrcRedacted := sourceMeta.GetDocumentMetadata().CloneAndRedact()
-						docMetaTgtRedacted := targetMeta.GetDocumentMetadata().CloneAndRedact()
-						xmem.Logger().Debugf("%v doc %v%s%v failed source side conflict resolution. source meta=%v, target meta=%v. no need to send\n", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd, docMetaSrcRedacted, docMetaTgtRedacted)
-					}
-					bigDoc_noRep_map[wrappedReq.UniqueKey] = NotSendFailedCR
-				case base.SendToTarget:
-					if xmem.Logger().GetLogLevel() >= log.LogLevelDebug {
-						sourceDoc := crMeta.NewSourceDocument(wrappedReq, xmem.sourceBucketId)
-						sourceMeta, err := sourceDoc.GetMetadata()
-						if err != nil {
-							xmem.Logger().Warnf("%v batchGetMeta: Error decoding source document metadata for doc %v%q%v. err=%v. Skip conflict resolution and send the doc", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd, err)
-							continue
-						}
-						targetDoc, err := crMeta.NewTargetDocument([]byte(key), resp, nil, xmem.targetBucketId, xmem.xattrEnabled, false)
-						if err == base.ErrorDocumentNotFound {
-							xmem.Logger().Warnf("%v batchGetMeta: doc %v%q%v won source side conflict resolution because target document does not exist.",
-								xmem.Id(), base.UdTagBegin, key, base.UdTagEnd)
-							continue
-						}
-						targetMeta, err := targetDoc.GetMetadata()
-						if err != nil {
-							xmem.Logger().Warnf("%v batchGetMeta: Error decoding target document metadata for doc %v%q%v. err=%v. Skip conflict resolution and send the doc", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd, err)
-							continue
-						}
-						docMetaSrcRedacted := sourceMeta.GetDocumentMetadata().CloneAndRedact()
-						docMetaTgtRedacted := targetMeta.GetDocumentMetadata().CloneAndRedact()
-						xmem.Logger().Debugf("%v doc %v%s%v succeeded source side conflict resolution. source meta=%v, target meta=%v. sending it to target\n", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd, docMetaSrcRedacted, docMetaTgtRedacted)
-					}
-				default:
-					panic(fmt.Sprintf("batchGetMeta: unespected CR result %v for key %v%q%v", res, base.UdTagBegin, key, base.UdTagEnd))
-				}
-			}
-		} else if ok && base.IsTopologyChangeMCError(resp.Status) {
-			bigDoc_noRep_map[wrappedReq.UniqueKey] = NotSendOther
-
-		} else if ok && base.IsCollectionMappingError(resp.Status) {
-			if xmem.Logger().GetLogLevel() >= log.LogLevelDebug {
-				xmem.Logger().Debugf("%v batchGetMeta: doc %v%s%v could not be mapped to on target even though manifest says it exists. Skip conflict resolution and send the doc", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd)
-			}
-		} else {
-			if !ok || resp == nil {
-				if xmem.Logger().GetLogLevel() >= log.LogLevelDebug {
-					xmem.Logger().Debugf("%v batchGetMeta: doc %v%s%v is not found in target system, send it", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd)
-				}
-			} else if resp.Status == mc.KEY_ENOENT {
-				if xmem.Logger().GetLogLevel() >= log.LogLevelDebug {
-					xmem.Logger().Debugf("%v batchGetMeta: doc %v%s%v does not exist on target. Skip conflict resolution and send the doc", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd)
-				}
-			} else {
-				xmem.Logger().Warnf("%v batchGetMeta: memcached response for doc %v%s%v has error status %v. Skip conflict resolution and send the doc", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd, resp.Status)
-			}
-		}
-	}
-
-	if xmem.Logger().GetLogLevel() >= log.LogLevelDebug {
-		xmem.Logger().Debugf("%v Done with batchGetMeta, bigDoc_noRep_map=%v\n", xmem.Id(), bigDoc_noRep_map.CloneAndRedact())
-	}
-	return bigDoc_noRep_map, nil
-}
-
-func (xmem *XmemNozzle) composeRequestForGetMeta(key string, vb uint16, opaque uint32) *mc.MCRequest {
+func (xmem *XmemNozzle) composeRequestForGetMeta(key []byte, vb uint16, opaque uint32) *mc.MCRequest {
 	req := &mc.MCRequest{VBucket: vb,
-		Key:    []byte(key),
+		Key:    key,
 		Opaque: opaque,
 		Opcode: base.GET_WITH_META}
 
@@ -1753,16 +1629,14 @@ func (xmem *XmemNozzle) composeRequestForGetMeta(key string, vb uint16, opaque u
 	return req
 }
 
-// For eqch document in the get_map, this routine will compose subdoc_get using the getSpec, or getMeta if getSpec is not provided, and send the requests
-func (xmem *XmemNozzle) sendBatchGetRequest(get_map base.McRequestMap, retry int, getSpec []base.SubdocLookupPathSpec) (respMap base.MCResponseMap, err error) {
+// For each document in the get_map, this routine will compose subdoc_get or getMeta, and send the requests
+func (xmem *XmemNozzle) sendBatchGetRequest(get_map base.McRequestMap, retry int, getSpecWithHlv, getSpecWithoutHlv []base.SubdocLookupPathSpec) (respMap map[string]*base.SubdocLookupResponse, err error) {
 	// if input size is 0, then we are done
 	if len(get_map) == 0 {
 		return nil, nil
 	}
 
-	isGetMeta := len(getSpec) == 0
-
-	respMap = make(base.MCResponseMap, xmem.config.maxCount)
+	respMap = make(map[string]*base.SubdocLookupResponse, xmem.config.maxCount)
 
 	opaque_keySeqno_map := make(opaqueKeySeqnoMap)
 	receiver_fin_ch := make(chan bool, 1)
@@ -1775,11 +1649,13 @@ func (xmem *XmemNozzle) sendBatchGetRequest(get_map base.McRequestMap, retry int
 	reqs_bytes := [][]byte{}
 	// Counts the number of requests that will fit into each req_bytes slice
 	numOfReqsInReqBytesBatch := 0
-	totalNumOfReqsForGet := 0
+	totalNumOfReqsForSubdocGet := 0
+	totalNumOfReqsForGetMeta := 0
 
 	// Establish an opaque based on the current time - and since getting doc doesn't utilize buffer buckets, feed it 0
 	opaque := base.GetOpaque(0, uint16(time.Now().UnixNano()))
 	sent_key_map := make(map[string]bool, len(get_map))
+	getSpecMap := make(map[string][]base.SubdocLookupPathSpec)
 
 	//de-dupe and prepare the packages
 	for _, originalReq := range get_map {
@@ -1791,19 +1667,17 @@ func (xmem *XmemNozzle) sendBatchGetRequest(get_map base.McRequestMap, retry int
 		}
 
 		if _, ok := sent_key_map[docKey]; !ok {
-			var req *mc.MCRequest
-			if isGetMeta {
-				req = xmem.composeRequestForGetMeta(docKey, originalReq.Req.VBucket, opaque)
-			} else {
-				req = xmem.composeRequestForSubdocGet(getSpec, docKey, originalReq.Req.VBucket, opaque)
+			req, getSpec := xmem.composeRequestForGet(originalReq.Req, getSpecWithHlv, getSpecWithoutHlv, opaque)
+			if getSpec != nil {
+				getSpecMap[docKey] = getSpec
 			}
+
 			// .Bytes() returns data ready to be fed over the wire
 			reqs_bytes = append(reqs_bytes, req.Bytes())
 			// a Map of array of items and map key is the opaque currently based on time (passed to the target and back)
 			opaque_keySeqno_map[opaque] = compileOpaqueKeySeqnoValue(docKey, originalReq.Seqno, originalReq.Req.VBucket, time.Now(), originalReq.GetManifestId())
 			opaque++
 			numOfReqsInReqBytesBatch++
-			totalNumOfReqsForGet++
 			sent_key_map[docKey] = true
 
 			if numOfReqsInReqBytesBatch > base.XmemMaxBatchSize {
@@ -1811,6 +1685,11 @@ func (xmem *XmemNozzle) sendBatchGetRequest(get_map base.McRequestMap, retry int
 				reqs_bytes_list = append(reqs_bytes_list, reqs_bytes)
 				numOfReqsInReqBytesBatch = 0
 				reqs_bytes = [][]byte{}
+			}
+			if req.Opcode == base.GET_WITH_META {
+				totalNumOfReqsForGetMeta++
+			} else {
+				totalNumOfReqsForSubdocGet++
 			}
 		}
 	}
@@ -1821,15 +1700,15 @@ func (xmem *XmemNozzle) sendBatchGetRequest(get_map base.McRequestMap, retry int
 	}
 
 	// launch the receiver - passing channel and maps in are fine since they are "reference types"
-	go xmem.batchGetHandler(len(opaque_keySeqno_map), receiver_fin_ch, receiver_return_ch, opaque_keySeqno_map, respMap, xmem.Logger(), false /* isGetMeta */)
+	go xmem.batchGetHandler(len(opaque_keySeqno_map), receiver_fin_ch, receiver_return_ch, opaque_keySeqno_map, respMap, getSpecMap, xmem.Logger())
 
 	//send the requests
 	for _, packet := range reqs_bytes_list {
-		if isGetMeta {
-			// We are doing getMeta. Failure is tolerated.
+		if totalNumOfReqsForSubdocGet == 0 {
+			// We are doing getMeta only. Failure is tolerated.
 			err, _ = xmem.writeToClient(xmem.client_for_getMeta, packet, true)
 		} else {
-			// We are getting subdoc. The get must succeed. Do sendWithRetry
+			// We have some subdoc lookup. The get must succeed. Do sendWithRetry
 			err = xmem.sendWithRetry(xmem.client_for_getMeta, retry, packet)
 		}
 		if err != nil {
@@ -1838,10 +1717,11 @@ func (xmem *XmemNozzle) sendBatchGetRequest(get_map base.McRequestMap, retry int
 			return
 		}
 	}
-	if isGetMeta {
-		atomic.AddUint64(&xmem.counterNumGetMeta, uint64(totalNumOfReqsForGet))
-	} else {
-		atomic.AddUint64(&xmem.counterNumSubdocGet, uint64(totalNumOfReqsForGet))
+	if totalNumOfReqsForGetMeta > 0 {
+		atomic.AddUint64(&xmem.counterNumGetMeta, uint64(totalNumOfReqsForGetMeta))
+	}
+	if totalNumOfReqsForSubdocGet > 0 {
+		atomic.AddUint64(&xmem.counterNumSubdocGet, uint64(totalNumOfReqsForSubdocGet))
 	}
 	//wait for receiver to finish
 	<-receiver_return_ch
@@ -1849,31 +1729,37 @@ func (xmem *XmemNozzle) sendBatchGetRequest(get_map base.McRequestMap, retry int
 	return
 }
 
-// This routine will call subdoc_get using the provided spec and return all the result in the result_map
+// This routine will call either getMeta or subdoc_multi_lookup based on the specs set for the batch and the mutation,
+// and return all the result in the result_map
 // Input:
 // - get_map: the documents we want to fetch from target. When this call returns, get_map will be empty
-// - getSpec: the spec for subdoc_get paths
+// - getSpecWithHlv: the spec for subdoc_get paths, if nil, getMeta will be used.
+// - getSpecWithoutHlv: the spec if not CCR and enableCrossClusterVersion is off. If nil, getMeta will be used
 // Output:
 // - noRep_map: the documents we don't need to send to target
-// - conflict_map: These documents have conflict. These are also in noRep_map with corresponding NeedSendStatus
 // - sendLookup_map: the response for documents we need to send to target. These are not in noRep_map.
+// - conflict_map: These documents have conflict. These are also in noRep_map with corresponding NeedSendStatus
 // - mergeLookup_map: The response for the documents in conflict_map
-func (xmem *XmemNozzle) batchSubDocGet(get_map base.McRequestMap, getSpec []base.SubdocLookupPathSpec) (noRep_map map[string]NeedSendStatus,
+func (xmem *XmemNozzle) batchGet(get_map base.McRequestMap, getSpecWithHlv, getSpecWithoutHlv []base.SubdocLookupPathSpec) (noRep_map map[string]NeedSendStatus,
 	conflict_map base.McRequestMap, sendLookup_map, mergeLookup_map map[string]*base.SubdocLookupResponse, err error) {
 
 	noRep_map = make(map[string]NeedSendStatus)
 	conflict_map = make(base.McRequestMap)
 	sendLookup_map = make(map[string]*base.SubdocLookupResponse)
 	mergeLookup_map = make(map[string]*base.SubdocLookupResponse)
-	var respMap base.MCResponseMap
+	var respMap map[string]*base.SubdocLookupResponse
 	var hasTmpErr bool
 	for i := 0; i < xmem.config.maxRetry || hasTmpErr; i++ {
+		if len(get_map) == 0 {
+			// Got all result
+			return
+		}
 		err = xmem.validateRunningState()
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
 		hasTmpErr = false
-		respMap, err = xmem.sendBatchGetRequest(get_map, xmem.config.maxRetry, getSpec)
+		respMap, err = xmem.sendBatchGetRequest(get_map, xmem.config.maxRetry, getSpecWithHlv, getSpecWithoutHlv)
 		if err != nil {
 			// Log the error. We will retry maxRetry times.
 			xmem.Logger().Errorf("sentBatchGetRequest returned error '%v'. Retry number %v", err, i)
@@ -1882,13 +1768,22 @@ func (xmem *XmemNozzle) batchSubDocGet(get_map base.McRequestMap, getSpec []base
 		for uniqueKey, wrappedReq := range get_map {
 			key := string(wrappedReq.Req.Key)
 			resp, ok := respMap[key]
-			if ok && (resp.Status == mc.KEY_ENOENT || base.IsSuccessSubdocLookupResponse(resp)) {
+			if ok && (resp.Resp.Status == mc.KEY_ENOENT) {
+				sendLookup_map[uniqueKey] = resp
+				delete(get_map, uniqueKey)
+			} else if ok && base.IsDocLocked(resp.Resp) {
+				if xmem.Logger().GetLogLevel() >= log.LogLevelDebug {
+					xmem.Logger().Debugf("%v doc %v%q%v is locked on the target, opcode=%v, cas=%v, status=%v. will need to retry\n", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd, resp.Resp.Opcode, resp.Resp.Cas, resp.Resp.Status)
+				}
+				noRep_map[uniqueKey] = RetryTargetLocked
+				delete(get_map, uniqueKey)
+			} else if ok && base.IsSuccessGetResponse(resp.Resp) {
 				if err = xmem.uncompressBody(wrappedReq); err != nil {
 					xmem.Logger().Errorf("%v failed to uncompress %v%q%v: '%v'", xmem.Id(), base.UdTagBegin, key, base.UdTagEnd, err)
 					return nil, nil, nil, nil, err
 				}
 				var res base.ConflictResult
-				res, err = xmem.conflict_resolver(wrappedReq, resp, getSpec, xmem.sourceBucketId, xmem.targetBucketId, xmem.xattrEnabled, xmem.Logger())
+				res, err = xmem.conflict_resolver(wrappedReq, resp.Resp, resp.Specs, xmem.sourceBucketId, xmem.targetBucketId, xmem.xattrEnabled, xmem.Logger())
 				if err != nil {
 					// Log the error. We will retry
 					xmem.Logger().Errorf("%v conflict_resolver: '%v'", xmem.Id(), err)
@@ -1896,33 +1791,33 @@ func (xmem *XmemNozzle) batchSubDocGet(get_map base.McRequestMap, getSpec []base
 				}
 				switch res {
 				case base.SendToTarget:
-					sendLookup_map[uniqueKey] = &base.SubdocLookupResponse{getSpec, resp}
+					sendLookup_map[uniqueKey] = resp
 				case base.Skip:
 					noRep_map[uniqueKey] = NotSendFailedCR
 				case base.Merge:
 					noRep_map[uniqueKey] = NotSendMerge
 					conflict_map[uniqueKey] = wrappedReq
-					mergeLookup_map[uniqueKey] = &base.SubdocLookupResponse{getSpec, resp}
+					mergeLookup_map[uniqueKey] = resp
 				case base.SetBackToSource:
 					noRep_map[uniqueKey] = NotSendSetback
 					conflict_map[uniqueKey] = wrappedReq
-					mergeLookup_map[uniqueKey] = &base.SubdocLookupResponse{getSpec, resp}
+					mergeLookup_map[uniqueKey] = resp
 				default:
 					panic(fmt.Sprintf("Unexpcted conflict result %v", res))
 				}
 				delete(get_map, uniqueKey)
+			} else if opcode, _ := xmem.opcodeAndSpecsForGetOp(wrappedReq.Req, getSpecWithHlv, getSpecWithoutHlv); opcode == base.GET_WITH_META {
+				// For getMeta, we can just send optimistically
+				sendLookup_map[uniqueKey] = resp
+				delete(get_map, uniqueKey)
 			} else if resp != nil {
-				if base.IsTemporaryMCError(resp.Status) {
+				if base.IsTemporaryMCError(resp.Resp.Status) {
 					hasTmpErr = true
 				}
-				if xmem.Logger().GetLogLevel() >= log.LogLevelDebug {
-					xmem.Logger().Debugf("Received %v for key %v", xmem.PrintResponseStatusError(resp.Status), key)
+				if xmem.Logger().GetLogLevel() >= log.LogLevelDebug && resp.Resp != nil {
+					xmem.Logger().Debugf("Received %v for key %v", xmem.PrintResponseStatusError(resp.Resp.Status), key)
 				}
 			}
-		}
-		if len(get_map) == 0 {
-			// Got all result
-			return
 		}
 	}
 	if len(get_map) > 0 {
@@ -1931,8 +1826,32 @@ func (xmem *XmemNozzle) batchSubDocGet(get_map base.McRequestMap, getSpec []base
 	return
 }
 
+func (xmem *XmemNozzle) opcodeAndSpecsForGetOp(incomingReq *mc.MCRequest, getSpecWithHlv, getSpecWithoutHlv []base.SubdocLookupPathSpec) (mc.CommandCode, []base.SubdocLookupPathSpec) {
+	var getSpecs []base.SubdocLookupPathSpec
+	if xmem.source_cr_mode == base.CRMode_Custom {
+		getSpecs = getSpecWithHlv
+	} else if xmem.getCrossClusterVers() == true && incomingReq.Cas >= xmem.config.vbMaxCas[incomingReq.VBucket] {
+		// These are the mutations we need to maintain HLV for mobile and get target importCas/cvCas for CR
+		getSpecs = getSpecWithHlv
+	} else {
+		getSpecs = getSpecWithoutHlv
+	}
+	if getSpecs == nil {
+		return base.GET_WITH_META, nil
+	}
+	return base.SUBDOC_MULTI_MUTATION, getSpecs
+}
+
+func (xmem *XmemNozzle) composeRequestForGet(incomingReq *mc.MCRequest, getSpecWithHlv, getSpecWithoutHlv []base.SubdocLookupPathSpec, opaque uint32) (*mc.MCRequest, []base.SubdocLookupPathSpec) {
+	opcode, specs := xmem.opcodeAndSpecsForGetOp(incomingReq, getSpecWithHlv, getSpecWithoutHlv)
+	if opcode == base.GET_WITH_META {
+		return xmem.composeRequestForGetMeta(incomingReq.Key, incomingReq.VBucket, opaque), nil
+	}
+	return xmem.composeRequestForSubdocGet(specs, incomingReq.Key, incomingReq.VBucket, opaque), specs
+}
+
 // Request to get _xdcr XATTR. If document body is included, it must be the last path
-func (xmem *XmemNozzle) composeRequestForSubdocGet(specs []base.SubdocLookupPathSpec, key string, vb uint16, opaque uint32) *mc.MCRequest {
+func (xmem *XmemNozzle) composeRequestForSubdocGet(specs []base.SubdocLookupPathSpec, key []byte, vb uint16, opaque uint32) *mc.MCRequest {
 	bodylen := 0
 	for i := 0; i < len(specs); i++ {
 		bodylen = bodylen + specs[i].Size()
@@ -1955,7 +1874,7 @@ func (xmem *XmemNozzle) composeRequestForSubdocGet(specs []base.SubdocLookupPath
 
 	return &mc.MCRequest{
 		VBucket: vb,
-		Key:     []byte(key),
+		Key:     key,
 		Opaque:  opaque,
 		Extras:  []byte{mc.SUBDOC_FLAG_ACCESS_DELETED},
 		Body:    body,
@@ -1994,11 +1913,26 @@ func (xmem *XmemNozzle) uncompressBody(req *base.WrappedMCRequest) error {
 	return nil
 }
 func (xmem *XmemNozzle) updateSystemXattrForTarget(wrappedReq *base.WrappedMCRequest, lookup *base.SubdocLookupResponse, setOpt SetMetaXattrOptions) (err error) {
-	if !setOpt.sendHlv && !setOpt.preserveSync {
+	var needToUpdateSysXattrs bool
+	if wrappedReq.Req.DataType&mcc.XattrDataType != 0 {
+		// in this case, we may need to update HLV if source already has it, even if mobile/HLV are all off.
+		needToUpdateSysXattrs = true
+	} else if setOpt.preserveSync {
+		needToUpdateSysXattrs = true
+	} else if xmem.source_cr_mode == base.CRMode_Custom {
+		needToUpdateSysXattrs = true
+	} else if setOpt.sendHlv {
+		maxCas := xmem.config.vbMaxCas[wrappedReq.Req.VBucket]
+		if wrappedReq.Req.Cas >= maxCas {
+			needToUpdateSysXattrs = true
+		}
+	}
+
+	if !needToUpdateSysXattrs {
 		return
 	}
-	if err := xmem.uncompressBody(wrappedReq); err != nil {
-		return err
+	if err = xmem.uncompressBody(wrappedReq); err != nil {
+		return
 	}
 
 	maxBodyIncrease := 0
@@ -2011,7 +1945,7 @@ func (xmem *XmemNozzle) updateSystemXattrForTarget(wrappedReq *base.WrappedMCReq
 			18 /* "0x<16byte>"} */
 	}
 	var targetSyncVal []byte
-	if setOpt.preserveSync {
+	if setOpt.preserveSync && lookup != nil {
 		targetSyncVal, _ = lookup.ResponseForAPath(base.XATTR_MOBILE)
 		maxBodyIncrease = maxBodyIncrease + len(targetSyncVal)
 	}
@@ -2044,7 +1978,7 @@ func (xmem *XmemNozzle) updateSystemXattrForTarget(wrappedReq *base.WrappedMCReq
 			return err
 		}
 
-		if crMeta.NeedToUpdateHlv(meta, time.Duration(atomic.LoadUint32(&xmem.config.hlvPruningWindowSec))*time.Second) {
+		if crMeta.NeedToUpdateHlv(meta, xmem.config.vbMaxCas[req.VBucket], time.Duration(atomic.LoadUint32(&xmem.config.hlvPruningWindowSec))*time.Second) {
 			_, err = crMeta.ConstructXattrFromHlvForSetMeta(meta, time.Duration(atomic.LoadUint32(&xmem.config.hlvPruningWindowSec))*time.Second, xattrComposer)
 			if err != nil {
 				return err
@@ -2286,6 +2220,8 @@ func (xmem *XmemNozzle) getPoolName() string {
 	return xmem.config.connPoolNamePrefix + base.KeyPartsDelimiter + "Couch_Xmem_" + xmem.config.connectStr + base.KeyPartsDelimiter + xmem.config.bucketName
 }
 
+// setMetaXattrOptions.noTargetCR is not set for the batch. It is set whenever subdoc get is used.
+// For mixed mode where old mutations uses getMeta (mobile=off), target CR is used
 func (xmem *XmemNozzle) initNewBatch() {
 	xmem.batch = newBatch(uint32(xmem.config.maxCount), uint32(xmem.config.maxSize), xmem.Logger())
 	atomic.StoreUint32(&xmem.cur_batch_count, 0)
@@ -2295,35 +2231,23 @@ func (xmem *XmemNozzle) initNewBatch() {
 	crossClusterVers := xmem.getCrossClusterVers()
 	isMobile := xmem.getMobileCompatible() != base.MobileCompatibilityOff
 
-	// If it is CCR, we need to get target version vector for conflict detection
-	// If mobile on, we need to preserve target _sync XATTR so get _sync
-	if isCCR || isMobile || crossClusterVers {
-		option := base.SubdocSpecOption{
-			IncludeHlv:        isCCR || crossClusterVers, // CCR needs target HLV for CR. crossClusterVers needs cvCas
-			IncludeMobileSync: isMobile,                  // For mobile, we need to get target _sync so we can preserve it
-			IncludeImportCas:  crossClusterVers,
-			IncludeBody:       false,
-			IncludeVXattr:     true, // Get all the document metadata since we won't be calling getMeta
-		}
-		xmem.batch.getMetaSpec = base.ComposeSpecForSubdocGet(option)
-		option.IncludeBody = true
-		xmem.batch.getBodySpec = base.ComposeSpecForSubdocGet(option)
-
-	} else {
-		//  Use getMeta
-		xmem.batch.getMetaSpec = nil
-		xmem.batch.getBodySpec = nil
-	}
-
-	// SetMeta behavior for the batch
+	option := base.SubdocSpecOption{}
 	if isMobile {
 		xmem.batch.setMetaXattrOptions.preserveSync = true
-	}
-	if isCCR || isMobile {
-		xmem.batch.setMetaXattrOptions.noTargetCR = true
+		option.IncludeMobileSync = true
+		option.IncludeVXattr = true
+		// For mixed mode, we never need to get target HLV
+		xmem.batch.getMetaSpecWithoutHlv = base.ComposeSpecForSubdocGet(option)
 	}
 	if crossClusterVers || isCCR {
 		xmem.batch.setMetaXattrOptions.sendHlv = true
+		option.IncludeImportCas = crossClusterVers
+		option.IncludeHlv = true // CCR needs target HLV for CR, crossClusterVers needs cvCas
+		option.IncludeVXattr = true
+		xmem.batch.getMetaSpecWithHlv = base.ComposeSpecForSubdocGet(option)
+		// This is only needed for CCR
+		option.IncludeBody = true
+		xmem.batch.getBodySpec = base.ComposeSpecForSubdocGet(option)
 	}
 }
 
@@ -3168,7 +3092,8 @@ func (xmem *XmemNozzle) handleGeneralError(err error) {
 }
 
 func (xmem *XmemNozzle) optimisticRep(req *mc.MCRequest) bool {
-	if len(xmem.batch.getMetaSpec) > 0 {
+	opcode, _ := xmem.opcodeAndSpecsForGetOp(req, xmem.batch.getMetaSpecWithHlv, xmem.batch.getMetaSpecWithoutHlv)
+	if opcode == base.SUBDOC_MULTI_MUTATION {
 		// If we need to get anything from target, optimisticRep can't be used.
 		return false
 	}

--- a/parts/xmem_nozzle_test.go
+++ b/parts/xmem_nozzle_test.go
@@ -489,6 +489,7 @@ func TestMobilePreserveSync(t *testing.T) {
 		fmt.Println("Skipping since live cluster_run setup has not been detected")
 		return
 	}
+	// This is a revId bucket while other mobile tests use LWW bucket.
 	bucketName := "B0"
 	cluster, bucket, err := GetAndFlushBucket(targetConnStr, bucketName)
 	if err != nil {
@@ -666,7 +667,7 @@ func TestMobileImportCasLWW(t *testing.T) {
 	}
 	assert := assert.New(t)
 	// Create and flush target bucket
-	bucketName := "importLWW"
+	bucketName := "mobileLWW"
 	cluster, bucket, err := createBucket(targetConnStr, bucketName, "lww")
 	if err != nil {
 		fmt.Printf("TestMobileImportCasLWW skipped because bucket is cannot be created. Error: %v\n", err)
@@ -752,6 +753,102 @@ func TestMobileImportCasLWW(t *testing.T) {
 	out, err = bucket.DefaultCollection().Get(key, nil)
 	assert.Nil(err) // Should get a path not found error
 	assert.Equal(gocb.Cas(1700503747140517888), out.Cas())
+}
+
+func TestMobileMixedMode(t *testing.T) {
+	fmt.Println("============== Test case start: TestMobileMixedMode =================")
+	defer fmt.Println("============== Test case end: TestMobileMixedMode =================")
+	if !targetXmemIsUpAndCorrectSetupExists(xmemBucket) {
+		fmt.Println("Skipping since live cluster_run setup has not been detected")
+		return
+	}
+	assert := assert.New(t)
+	bucketName := "mobileLWW"
+	cluster, _, err := createBucket(targetConnStr, bucketName, "lww")
+	if err != nil {
+		fmt.Printf("TestMobileImportCasLWW skipped because bucket is cannot be created. Error: %v\n", err)
+		return
+	}
+	defer cluster.Close(nil)
+	// Create Xmem for testing
+	utilsNotUsed, settings, xmem, router, throttler, remoteClusterSvc, colManSvc, eventProducer := setupBoilerPlateXmem(bucketName, base.CRMode_LWW)
+	realUtils := utilsReal.NewUtilities()
+	xmem.utils = realUtils
+
+	settings[base.EnableCrossClusterVersioningKey] = true
+	settings[base.VersionPruningWindowHrsKey] = 720
+	router.setMobileCompatibility(base.MobileCompatibilityActive)
+
+	setupMocksXmem(xmem, utilsNotUsed, throttler, remoteClusterSvc, colManSvc, eventProducer)
+
+	settings[MOBILE_COMPATBILE] = base.MobileCompatibilityOff
+	xmem.sourceBucketUuid = "93fcf4f0fcc94fdb3d6196235029d6bf"
+	startTargetXmem(xmem, settings, bucketName, assert)
+	fmt.Println("=== Test mobile mixed mode with mobile off ===")
+	mobileMixedModeTest(xmem, router, settings, bucketName, assert)
+
+	fmt.Println("=== Test mobile mixed mode with mobile active ===")
+	xmem.config.mobileCompatible = base.MobileCompatibilityActive
+	mobileMixedModeTest(xmem, router, settings, bucketName, assert)
+}
+
+func mobileMixedModeTest(xmem *XmemNozzle, router *Router, settings map[string]interface{}, bucketName string, assert *assert.Assertions) {
+	_, bucket, err := GetAndFlushBucket(targetConnStr, bucketName)
+	if err != nil {
+		fmt.Printf("TestMobileImportCasLWW skipped because bucket cannot be flusehed. Error: %v\n", err)
+		return
+	}
+
+	uprfile := "./testdata/uprEventSyncTestDoc1WithSyncUpdated.json"
+	doc1event, err := RetrieveUprFile(uprfile)
+	assert.Nil(err)
+	doc1MCRequest, err := router.ComposeMCRequest(&base.WrappedUprEvent{UprEvent: doc1event})
+	assert.Nil(err)
+
+	uprfile = "./testdata/uprEventSyncTestDoc2Source.json"
+	doc2event, err := RetrieveUprFile(uprfile)
+	assert.Nil(err)
+	doc2MCRequest, err := router.ComposeMCRequest(&base.WrappedUprEvent{UprEvent: doc2event})
+	assert.Nil(err)
+
+	uprfile = "./testdata/uprEventDoc1UpdateAfterImport.json"
+	updatedImportEvent, err := RetrieveUprFile(uprfile)
+	assert.Nil(err)
+	updatedImportMCRequest, err := router.ComposeMCRequest(&base.WrappedUprEvent{UprEvent: updatedImportEvent})
+	assert.Nil(err)
+
+	xmem.config.vbMaxCas[doc1event.VBucket] = doc1event.Cas + 10                   // doc1 CAS is smaller
+	xmem.config.vbMaxCas[doc2event.VBucket] = doc2event.Cas - 10                   // doc2 CAS is larger
+	xmem.config.vbMaxCas[updatedImportEvent.VBucket] = updatedImportEvent.Cas + 10 // import CAS is smaller
+
+	xmem.Receive(doc1MCRequest)
+	xmem.Receive(doc2MCRequest)
+	xmem.Receive(updatedImportMCRequest)
+
+	err = waitForReplication(string(doc1event.Key), gocb.Cas(doc1event.Cas), bucket)
+	assert.Nil(err)
+	err = waitForReplication(string(doc2event.Key), gocb.Cas(doc2event.Cas), bucket)
+	assert.Nil(err)
+	err = waitForReplication(string(updatedImportEvent.Key), gocb.Cas(updatedImportEvent.Cas), bucket)
+	assert.Nil(err)
+
+	// Doc1 Cas is smaller than its vbMaxCas. So it does not have HLV
+	value, err := bucket.DefaultCollection().LookupIn(string(doc1event.Key),
+		[]gocb.LookupInSpec{gocb.GetSpec(base.XATTR_HLV, &gocb.GetSpecOptions{IsXattr: true})}, nil)
+	assert.Nil(err)
+	assert.False(value.Exists(0))
+
+	// Doc2 Cas is larger than its vbMaxCas. So it does  have HLV
+	value, err = bucket.DefaultCollection().LookupIn(string(doc2event.Key),
+		[]gocb.LookupInSpec{gocb.GetSpec(base.XATTR_HLV, &gocb.GetSpecOptions{IsXattr: true})}, nil)
+	assert.Nil(err)
+	assert.True(value.Exists(0))
+
+	// The import doc Cas is smaller than its vbMaxCas, but it already has HLV. So the HLV gets updated
+	value, err = bucket.DefaultCollection().LookupIn(string(updatedImportEvent.Key),
+		[]gocb.LookupInSpec{gocb.GetSpec(base.XATTR_HLV, &gocb.GetSpecOptions{IsXattr: true})}, nil)
+	assert.Nil(err)
+	assert.True(value.Exists(0))
 }
 
 // This routine was used to generate import mutations used in TestMobileImportCasLWW.

--- a/service_def/conflictMgrIface.go
+++ b/service_def/conflictMgrIface.go
@@ -16,6 +16,6 @@ import (
 )
 
 type ConflictManagerIface interface {
-	ResolveConflict(source *base.WrappedMCRequest, target *base.SubdocLookupResponse, sourceId, targetId hlv.DocumentSourceId, recycler func(*base.WrappedMCRequest)) error
-	SetBackToSource(source *base.WrappedMCRequest, target *base.SubdocLookupResponse, sourceId, targetId hlv.DocumentSourceId, recycler func(*base.WrappedMCRequest)) error
+	ResolveConflict(source *base.WrappedMCRequest, target *base.SubdocLookupResponse, sourceId, targetId hlv.DocumentSourceId, uncompressFunc base.UncompressFunc, recycler func(*base.WrappedMCRequest)) error
+	SetBackToSource(source *base.WrappedMCRequest, target *base.SubdocLookupResponse, sourceId, targetId hlv.DocumentSourceId, uncompressFunc base.UncompressFunc, recycler func(*base.WrappedMCRequest)) error
 }

--- a/service_def/mocks/mock_ConflictManagerIface.go
+++ b/service_def/mocks/mock_ConflictManagerIface.go
@@ -22,13 +22,13 @@ func (_m *ConflictManagerIface) EXPECT() *ConflictManagerIface_Expecter {
 	return &ConflictManagerIface_Expecter{mock: &_m.Mock}
 }
 
-// ResolveConflict provides a mock function with given fields: source, target, sourceId, targetId, recycler
-func (_m *ConflictManagerIface) ResolveConflict(source *base.WrappedMCRequest, target *base.SubdocLookupResponse, sourceId hlv.DocumentSourceId, targetId hlv.DocumentSourceId, recycler func(*base.WrappedMCRequest)) error {
-	ret := _m.Called(source, target, sourceId, targetId, recycler)
+// ResolveConflict provides a mock function with given fields: source, target, sourceId, targetId, uncompressFunc, recycler
+func (_m *ConflictManagerIface) ResolveConflict(source *base.WrappedMCRequest, target *base.SubdocLookupResponse, sourceId hlv.DocumentSourceId, targetId hlv.DocumentSourceId, uncompressFunc base.UncompressFunc, recycler func(*base.WrappedMCRequest)) error {
+	ret := _m.Called(source, target, sourceId, targetId, uncompressFunc, recycler)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*base.WrappedMCRequest, *base.SubdocLookupResponse, hlv.DocumentSourceId, hlv.DocumentSourceId, func(*base.WrappedMCRequest)) error); ok {
-		r0 = rf(source, target, sourceId, targetId, recycler)
+	if rf, ok := ret.Get(0).(func(*base.WrappedMCRequest, *base.SubdocLookupResponse, hlv.DocumentSourceId, hlv.DocumentSourceId, base.UncompressFunc, func(*base.WrappedMCRequest)) error); ok {
+		r0 = rf(source, target, sourceId, targetId, uncompressFunc, recycler)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -46,14 +46,15 @@ type ConflictManagerIface_ResolveConflict_Call struct {
 //   - target *base.SubdocLookupResponse
 //   - sourceId hlv.DocumentSourceId
 //   - targetId hlv.DocumentSourceId
+//   - uncompressFunc base.UncompressFunc
 //   - recycler func(*base.WrappedMCRequest)
-func (_e *ConflictManagerIface_Expecter) ResolveConflict(source interface{}, target interface{}, sourceId interface{}, targetId interface{}, recycler interface{}) *ConflictManagerIface_ResolveConflict_Call {
-	return &ConflictManagerIface_ResolveConflict_Call{Call: _e.mock.On("ResolveConflict", source, target, sourceId, targetId, recycler)}
+func (_e *ConflictManagerIface_Expecter) ResolveConflict(source interface{}, target interface{}, sourceId interface{}, targetId interface{}, uncompressFunc interface{}, recycler interface{}) *ConflictManagerIface_ResolveConflict_Call {
+	return &ConflictManagerIface_ResolveConflict_Call{Call: _e.mock.On("ResolveConflict", source, target, sourceId, targetId, uncompressFunc, recycler)}
 }
 
-func (_c *ConflictManagerIface_ResolveConflict_Call) Run(run func(source *base.WrappedMCRequest, target *base.SubdocLookupResponse, sourceId hlv.DocumentSourceId, targetId hlv.DocumentSourceId, recycler func(*base.WrappedMCRequest))) *ConflictManagerIface_ResolveConflict_Call {
+func (_c *ConflictManagerIface_ResolveConflict_Call) Run(run func(source *base.WrappedMCRequest, target *base.SubdocLookupResponse, sourceId hlv.DocumentSourceId, targetId hlv.DocumentSourceId, uncompressFunc base.UncompressFunc, recycler func(*base.WrappedMCRequest))) *ConflictManagerIface_ResolveConflict_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*base.WrappedMCRequest), args[1].(*base.SubdocLookupResponse), args[2].(hlv.DocumentSourceId), args[3].(hlv.DocumentSourceId), args[4].(func(*base.WrappedMCRequest)))
+		run(args[0].(*base.WrappedMCRequest), args[1].(*base.SubdocLookupResponse), args[2].(hlv.DocumentSourceId), args[3].(hlv.DocumentSourceId), args[4].(base.UncompressFunc), args[5].(func(*base.WrappedMCRequest)))
 	})
 	return _c
 }
@@ -63,18 +64,18 @@ func (_c *ConflictManagerIface_ResolveConflict_Call) Return(_a0 error) *Conflict
 	return _c
 }
 
-func (_c *ConflictManagerIface_ResolveConflict_Call) RunAndReturn(run func(*base.WrappedMCRequest, *base.SubdocLookupResponse, hlv.DocumentSourceId, hlv.DocumentSourceId, func(*base.WrappedMCRequest)) error) *ConflictManagerIface_ResolveConflict_Call {
+func (_c *ConflictManagerIface_ResolveConflict_Call) RunAndReturn(run func(*base.WrappedMCRequest, *base.SubdocLookupResponse, hlv.DocumentSourceId, hlv.DocumentSourceId, base.UncompressFunc, func(*base.WrappedMCRequest)) error) *ConflictManagerIface_ResolveConflict_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// SetBackToSource provides a mock function with given fields: source, target, sourceId, targetId, recycler
-func (_m *ConflictManagerIface) SetBackToSource(source *base.WrappedMCRequest, target *base.SubdocLookupResponse, sourceId hlv.DocumentSourceId, targetId hlv.DocumentSourceId, recycler func(*base.WrappedMCRequest)) error {
-	ret := _m.Called(source, target, sourceId, targetId, recycler)
+// SetBackToSource provides a mock function with given fields: source, target, sourceId, targetId, uncompressFunc, recycler
+func (_m *ConflictManagerIface) SetBackToSource(source *base.WrappedMCRequest, target *base.SubdocLookupResponse, sourceId hlv.DocumentSourceId, targetId hlv.DocumentSourceId, uncompressFunc base.UncompressFunc, recycler func(*base.WrappedMCRequest)) error {
+	ret := _m.Called(source, target, sourceId, targetId, uncompressFunc, recycler)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*base.WrappedMCRequest, *base.SubdocLookupResponse, hlv.DocumentSourceId, hlv.DocumentSourceId, func(*base.WrappedMCRequest)) error); ok {
-		r0 = rf(source, target, sourceId, targetId, recycler)
+	if rf, ok := ret.Get(0).(func(*base.WrappedMCRequest, *base.SubdocLookupResponse, hlv.DocumentSourceId, hlv.DocumentSourceId, base.UncompressFunc, func(*base.WrappedMCRequest)) error); ok {
+		r0 = rf(source, target, sourceId, targetId, uncompressFunc, recycler)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -92,14 +93,15 @@ type ConflictManagerIface_SetBackToSource_Call struct {
 //   - target *base.SubdocLookupResponse
 //   - sourceId hlv.DocumentSourceId
 //   - targetId hlv.DocumentSourceId
+//   - uncompressFunc base.UncompressFunc
 //   - recycler func(*base.WrappedMCRequest)
-func (_e *ConflictManagerIface_Expecter) SetBackToSource(source interface{}, target interface{}, sourceId interface{}, targetId interface{}, recycler interface{}) *ConflictManagerIface_SetBackToSource_Call {
-	return &ConflictManagerIface_SetBackToSource_Call{Call: _e.mock.On("SetBackToSource", source, target, sourceId, targetId, recycler)}
+func (_e *ConflictManagerIface_Expecter) SetBackToSource(source interface{}, target interface{}, sourceId interface{}, targetId interface{}, uncompressFunc interface{}, recycler interface{}) *ConflictManagerIface_SetBackToSource_Call {
+	return &ConflictManagerIface_SetBackToSource_Call{Call: _e.mock.On("SetBackToSource", source, target, sourceId, targetId, uncompressFunc, recycler)}
 }
 
-func (_c *ConflictManagerIface_SetBackToSource_Call) Run(run func(source *base.WrappedMCRequest, target *base.SubdocLookupResponse, sourceId hlv.DocumentSourceId, targetId hlv.DocumentSourceId, recycler func(*base.WrappedMCRequest))) *ConflictManagerIface_SetBackToSource_Call {
+func (_c *ConflictManagerIface_SetBackToSource_Call) Run(run func(source *base.WrappedMCRequest, target *base.SubdocLookupResponse, sourceId hlv.DocumentSourceId, targetId hlv.DocumentSourceId, uncompressFunc base.UncompressFunc, recycler func(*base.WrappedMCRequest))) *ConflictManagerIface_SetBackToSource_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*base.WrappedMCRequest), args[1].(*base.SubdocLookupResponse), args[2].(hlv.DocumentSourceId), args[3].(hlv.DocumentSourceId), args[4].(func(*base.WrappedMCRequest)))
+		run(args[0].(*base.WrappedMCRequest), args[1].(*base.SubdocLookupResponse), args[2].(hlv.DocumentSourceId), args[3].(hlv.DocumentSourceId), args[4].(base.UncompressFunc), args[5].(func(*base.WrappedMCRequest)))
 	})
 	return _c
 }
@@ -109,7 +111,7 @@ func (_c *ConflictManagerIface_SetBackToSource_Call) Return(_a0 error) *Conflict
 	return _c
 }
 
-func (_c *ConflictManagerIface_SetBackToSource_Call) RunAndReturn(run func(*base.WrappedMCRequest, *base.SubdocLookupResponse, hlv.DocumentSourceId, hlv.DocumentSourceId, func(*base.WrappedMCRequest)) error) *ConflictManagerIface_SetBackToSource_Call {
+func (_c *ConflictManagerIface_SetBackToSource_Call) RunAndReturn(run func(*base.WrappedMCRequest, *base.SubdocLookupResponse, hlv.DocumentSourceId, hlv.DocumentSourceId, base.UncompressFunc, func(*base.WrappedMCRequest)) error) *ConflictManagerIface_SetBackToSource_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/tools/testScripts/miscTests/6b_targetLockedSubdoc.shlib
+++ b/tools/testScripts/miscTests/6b_targetLockedSubdoc.shlib
@@ -67,11 +67,10 @@ function runTestCase {
 	sleep 5
 	createRemoteClusterReference "C1" "C2"
 	sleep 1
+	setBucket "C1" "B1" "enableCrossClusterVersioning" "true"
+	setBucket "C2" "B2" "enableCrossClusterVersioning" "true"
 	createBucketReplication "C1" "B1" "C2" "B2" PessimisticReplicationProperties
 	setReplicationSettings "C1" "B1" "C2" "B2" "mobile=Active"
-	setBucket "C1" "B1" "enableCrossClusterVersioning" "true"
-	# Wait for replication to restart
-	sleep 15
 	printGlobalScopeAndCollectionInfo
 
 	echo "Writing a document with foo:bar"

--- a/tools/testScripts/miscTests/6b_targetLockedSubdoc.shlib
+++ b/tools/testScripts/miscTests/6b_targetLockedSubdoc.shlib
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -u
+
+# Copyright 2019-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included in
+# the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+# file, in accordance with the Business Source License, use of this software
+# will be governed by the Apache License, Version 2.0, included in the file
+# licenses/APL2.txt.
+
+# This is an example provision script that can be edited to quickly conjure up a
+# 2 1-node clusters, bidirectional replication to one another via a clean "cluster_run -n 2"
+# then load 10k documents on each bucket, resulting in 20k total docs per bucket after
+# bi-directional replication
+
+# main logic all exist elsewhere
+. ./clusterRunProvision.shlib
+if (($? != 0)); then
+	exit $?
+fi
+
+# set globals
+# -----------------
+DEFAULT_ADMIN="Administrator"
+DEFAULT_PW="wewewe"
+
+# =============================
+# topological map information
+# =============================
+# cluster -> Bucket(s)
+# -----------------
+CLUSTER_NAME_PORT_MAP=(["C1"]=9000 ["C2"]=9001)
+CLUSTER_NAME_XDCR_PORT_MAP=(["C1"]=13000 ["C2"]=13001)
+CLUSTER_NAME_KV_PORT_MAP=(["C1"]=12000 ["C2"]=12002)
+# Set c1 to have 2 buckets and c2 to have 1 bucket
+declare -a cluster1BucketsArr
+cluster1BucketsArr=("B0" "B1")
+CLUSTER_NAME_BUCKET_MAP=(["C1"]=${cluster1BucketsArr[@]} ["C2"]="B2")
+
+# Bucket properties
+declare -A LWWBucketProperty=(["ramQuotaMB"]=100 ["conflictResolutionType"]="lww")
+insertPropertyIntoBucketNamePropertyMap "B0" LWWBucketProperty
+insertPropertyIntoBucketNamePropertyMap "B1" LWWBucketProperty
+insertPropertyIntoBucketNamePropertyMap "B2" LWWBucketProperty
+
+declare -A PessimisticReplicationProperties=(["replicationType"]="continuous" ["checkpointInterval"]=60 ["statsInterval"]=500 ["optimisticReplicationThreshold"]=0 ["logLevel"]="Info")
+
+function runTestCase {
+	local docCount
+
+	echo "============================================================================"
+	echo "Running target document locked with mobile (subdoc) test case"
+	echo "============================================================================"
+
+	testForClusterRun
+	if (($? != 0)); then
+		exit $?
+	fi
+
+	setupTopologies
+	if (($? != 0)); then
+		exit $?
+	fi
+
+	# Wait for vbuckets and all the other things to propagate before XDCR provisioning
+	sleep 5
+	createRemoteClusterReference "C1" "C2"
+	sleep 1
+	createBucketReplication "C1" "B1" "C2" "B2" PessimisticReplicationProperties
+	setReplicationSettings "C1" "B1" "C2" "B2" "mobile=Active"
+	setBucket "C1" "B1" "enableCrossClusterVersioning" "true"
+	# Wait for replication to restart
+	sleep 15
+	printGlobalScopeAndCollectionInfo
+
+	echo "Writing a document with foo:bar"
+	writeJSONDocument "C1" "B1" "regDoc" '{"foo":"bar"}'
+	sleep 5
+
+	docCount=$(getJSONDocument "C2" "B2" "regDoc" | jq | grep -c "bar")
+	if (($docCount == 0)); then
+		echo "Unable to find initial doc replicated"
+		exit 1
+	fi
+
+	local timeToLock=30
+	echo "Locking document on target for $timeToLock seconds then write new doc to source to make sure it replicates eventually"
+	lockDocument "C2" "B2" "regDoc" $timeToLock
+	writeJSONDocument "C1" "B1" "regDoc" '{"foo":"bar2"}'
+
+	echo "Sleeping $(($timeToLock + 5)) for doc to be replicated"
+	sleep $(($timeToLock + 5))
+
+	checkUnidirectionalChangesLeft
+
+	docCount=$(getJSONDocument "C2" "B2" "regDoc" | jq | grep -c "bar2")
+	if (($docCount == 0)); then
+		echo "Unable to find updated doc replicated"
+		exit 1
+	fi
+
+	grepForPanics
+	echo "============================================================================"
+	echo "PASSED"
+	echo "============================================================================"
+
+	cleanupBucketReplications
+	cleanupBuckets
+	cleanupRemoteClusterRefs
+}


### PR DESCRIPTION
Mixed mode:
When enableCrossClusterVersioning is true for the bucket, the max_cas at that time is captured for each VB. The new mutations (those after the max_cas) has the full HLV and import support. For the old mutations (those before the max_cas), if it already has HLV, XDCR will update it.

Import is not supported during mixed mode. Mobile will disallow import operations until enableCrossClusterVersioning is true for all buckets, and all XDCR replications connecting the buckets have mobile set to active. Therefore XDCR will only fetch target importCas and HLV for new mutations.

1. Get target HLV and importCas only when enableCrossClusterVersioning = true and source doc.Cas >= max_cas for CR with target importCas/cvCas.
2. If enableCrossClusterVersioning is true: a. if doc CAS >= max cas: generate/update HLV b. if doc CAS < max cas, update HLV if doc already has it
3. If enableCrossClusterVersioning is false: a. update HLV if doc already has it
4. Refactor XMEM so a single batch can handle both subdoc_lookup and getMeta. a. When mobile = off, enableCrossClusterVersioning = false: - Normal CR with getMeta (no special handling for target import mutation, update HLV if doc has it) b. When mobile = off, enableCrossClusterVersioning = true: - if doc.Cas >= max_cas: subdoc_lookup (to get cvCas for import mutation handling) - if doc.Cas < max_cas: normal CR with getMeta. c. When mobile = active, enableCrossClusterVersioning = false: - same as 4.a except always use subdoc_lookup to get target _sync (preserve target) d. When mobile = active, enableCrossClusterVersioning = true: - same as 4.b except always use subdoc_lookup to get target _sync (preserve target)

Also added handling for subdoc_multi_lookup for locked documents.